### PR TITLE
Do not write --sentry-address command-line parameter if config value is empty or whitespace

### DIFF
--- a/src/Man.Dapr.Sidekick/Process/DaprSidecarProcess.cs
+++ b/src/Man.Dapr.Sidekick/Process/DaprSidecarProcess.cs
@@ -113,7 +113,7 @@ namespace Man.Dapr.Sidekick.Process
             .Add(ModeArgument, source.Mode)
             .Add(PlacementHostAddressArgument, source.PlacementHostAddress)
             .Add(ProfilePortArgument, source.ProfilePort, predicate: () => source.Profiling == true)
-            .Add(SentryAddressArgument, source.SentryAddress)
+            .Add(SentryAddressArgument, source.SentryAddress, predicate: () => !source.SentryAddress.IsNullOrWhiteSpaceEx())
             .Add(ConfigFileArgument, source.ConfigFile, predicate: () => File.Exists(source.ConfigFile))
             .Add(ComponentsPathArgument, source.ComponentsDirectory, predicate: () => Directory.Exists(source.ComponentsDirectory))
             .Add(source.CustomArguments, requiresValue: false);

--- a/src/Man.Dapr.Sidekick/StringExtensions.cs
+++ b/src/Man.Dapr.Sidekick/StringExtensions.cs
@@ -12,6 +12,7 @@
         /// <returns><c>true</c> if the value parameter is null or <see cref="string.Empty"/>, or if <paramref name="value"/> consists exclusively of white-space characters.</returns>
         public static bool IsNullOrWhiteSpaceEx(this string value)
         {
+#if NET35
             if (value == null)
             {
                 return true;
@@ -26,6 +27,9 @@
             }
 
             return true;
+#else
+            return string.IsNullOrWhiteSpace(value);
+#endif
         }
     }
 }

--- a/tests/Man.Dapr.Sidekick.Tests/Process/DaprSidecarProcessTests.cs
+++ b/tests/Man.Dapr.Sidekick.Tests/Process/DaprSidecarProcessTests.cs
@@ -112,6 +112,21 @@ namespace Man.Dapr.Sidekick.Process
             }
 
             [Test]
+            public void Should_not_add_empty_sentry_address()
+            {
+                var p = new MockDaprSidecarProcess();
+                var builder = new CommandLineArgumentBuilder();
+                var options = new DaprSidecarOptions
+                {
+                    SentryAddress = string.Empty
+                };
+
+                p.AddCommandLineArguments(options, builder);
+
+                Assert.That(builder.ToString(), Does.Not.Contain("sentry-address"));
+            }
+
+            [Test]
             public void Should_add_all_arguments()
             {
                 var p = new MockDaprSidecarProcess();


### PR DESCRIPTION
# Description

Ensure `--sentry-address` parameter is not passed to the `daprd` command-line if the `SentryAddress` option is null, empty or whitespace.

## Issue reference

Fixes Issue #10 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation where possible
