### PR TITLE
Add support for DAPRSIDEKICK_XXX variables

### DIFF
--- a/src/Man.Dapr.Sidekick.AspNetCore/DaprSidekickServiceCollectionExtensions.cs
+++ b/src/Man.Dapr.Sidekick.AspNetCore/DaprSidekickServiceCollectionExtensions.cs
@@ -65,7 +65,13 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var builder = AddCoreServices(services);
 
-            services.Configure<DaprOptions>(configuration.GetSection(name));
+                                            // Create a new configuration based on the initial configuration but with the additional
+            // support for setting/overriding top-level properties using environment variables.
+            var daprConfig = new ConfigurationBuilder()
+                .AddConfiguration(configuration.GetSection(name))
+                .AddEnvironmentVariables(DaprOptions.EnvironmentVariablePrefix)
+                .Build();
+            services.Configure<DaprOptions>(daprConfig);
 
             if (postConfigureAction != null)
             {

--- a/src/Man.Dapr.Sidekick.AspNetCore/Man.Dapr.Sidekick.AspNetCore.csproj
+++ b/src/Man.Dapr.Sidekick.AspNetCore/Man.Dapr.Sidekick.AspNetCore.csproj
@@ -9,6 +9,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />

--- a/src/Man.Dapr.Sidekick/Options/DaprOptions.cs
+++ b/src/Man.Dapr.Sidekick/Options/DaprOptions.cs
@@ -3,6 +3,7 @@
     public class DaprOptions : Options.DaprProcessOptions
     {
         public const string SectionName = "Dapr";
+        public const string EnvironmentVariablePrefix = "DAPRSIDEKICK_";
 
         public DaprOptions()
         {

--- a/tests/Man.Dapr.Sidekick.AspNetCore.Tests/DaprSidekickServiceCollectionExtensionsTests.cs
+++ b/tests/Man.Dapr.Sidekick.AspNetCore.Tests/DaprSidekickServiceCollectionExtensionsTests.cs
@@ -89,6 +89,32 @@ namespace Man.Dapr.Sidekick.AspNetCore.Sidecar
                 Assert.That(provider.GetRequiredService<IDaprProcessFactory>(), Is.Not.Null);
                 configuration.Received(1).GetSection("Dapr");
             }
+
+            [Test]
+            public void Should_extend_config_with_environmentvars()
+            {
+                var configuration = new ConfigurationBuilder()
+                    .AddCommandLine(new[]
+                    {
+                        DaprOptions.SectionName + ":BinDirectory=FROM_ARGS"
+                    })
+                    .Build();
+
+                // First check command
+                var services = new ServiceCollection();
+                services.AddDaprSidekick(configuration);
+                var provider = services.BuildServiceProvider();
+                var options = provider.GetRequiredService<IOptions<DaprOptions>>().Value;
+                Assert.That(options.BinDirectory, Is.EqualTo("FROM_ARGS"));
+
+                // Now add environment variables
+                Environment.SetEnvironmentVariable(DaprOptions.EnvironmentVariablePrefix + "BINDIRECTORY", "FROM_ENV");
+                services = new ServiceCollection();
+                services.AddDaprSidekick(configuration);
+                provider = services.BuildServiceProvider();
+                options = provider.GetRequiredService<IOptions<DaprOptions>>().Value;
+                Assert.That(options.BinDirectory, Is.EqualTo("FROM_ENV"));
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

It is now possible to define `DAPRSIDEKICK_XXX` variables to set or override top-level configuration options. Note that this feature is limited to those options defined in the [DaprProcessOptions](../blob/main/src/Man.Dapr.Sidekick/Options/DaprProcessOptions.cs) base class which will equalluy apply to either the `Sidecar`, `Placement` or `Sentry` processes depending which is configured.

For example you can now set `DAPRSIDEKICK_ENABLED=false` to completely disable Dapr Sidekick, which is useful if you are running inside a pod/container where Dapr is injected separately.

## Issue reference

Fixes Issue #9 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation where possible
