### PR TITLE
Return correct health status when attached

### DIFF
--- a/src/Man.Dapr.Sidekick.AspNetCore/DaprProcessHealthCheck.cs
+++ b/src/Man.Dapr.Sidekick.AspNetCore/DaprProcessHealthCheck.cs
@@ -23,8 +23,8 @@ namespace Man.Dapr.Sidekick
                 var processInfo = _daprProcessHost.GetProcessInfo();
                 if (processInfo.Status != DaprProcessStatus.Disabled)
                 {
-                    // Check to see if the process is running
-                    if (!processInfo.IsRunning)
+                    // Check to see if the process is running or attached
+                    if (!processInfo.IsRunning && !processInfo.IsAttached)
                     {
                         return new HealthCheckResult(context.Registration.FailureStatus, description: processInfo.Description);
                     }

--- a/src/Man.Dapr.Sidekick/Process/DaprProcessInfo.cs
+++ b/src/Man.Dapr.Sidekick/Process/DaprProcessInfo.cs
@@ -32,6 +32,7 @@
 
         public string Description =>
             IsRunning ? (!string.IsNullOrEmpty(Version) ? $"Dapr process '{Name}' running, version {Version}" : $"Dapr process '{Name}' running, unverified version") :
+            IsAttached ? (!string.IsNullOrEmpty(Version) ? $"Dapr process '{Name}' attached, version {Version}" : $"Dapr process '{Name}' attached, unverified version") :
             $"Dapr process '{Name}' not available, status is {Status}";
 
         public override string ToString() => Description;

--- a/tests/Man.Dapr.Sidekick.AspNetCore.Tests/DaprProcessHealthCheckTests.cs
+++ b/tests/Man.Dapr.Sidekick.AspNetCore.Tests/DaprProcessHealthCheckTests.cs
@@ -70,7 +70,7 @@ namespace Man.Dapr.Sidekick.AspNetCore
             }
 
             [Test]
-            public async Task Should_return_healthy()
+            public async Task Should_return_healthy_when_running()
             {
                 var cancellationToken = CancellationToken.None;
                 var host = Substitute.For<IDaprProcessHost>();
@@ -86,6 +86,25 @@ namespace Man.Dapr.Sidekick.AspNetCore
                 var result = await hc.CheckHealthAsync(context, cancellationToken);
                 Assert.That(result.Status, Is.EqualTo(HealthStatus.Healthy));
                 Assert.That(result.Description, Is.EqualTo("Dapr process 'P1' running, version 1234"));
+            }
+
+            [Test]
+            public async Task Should_return_healthy_when_attached()
+            {
+                var cancellationToken = CancellationToken.None;
+                var host = Substitute.For<IDaprProcessHost>();
+                var processInfo = new DaprProcessInfo("P1", 100, null, DaprProcessStatus.Stopped, true);
+                host.GetProcessInfo().Returns(processInfo);
+                host.GetHealthAsync(cancellationToken).Returns(Task.FromResult(new DaprHealthResult(System.Net.HttpStatusCode.OK)));
+                var hc = new MockDaprProcessHealthCheck(host);
+                var context = new HealthCheckContext
+                {
+                    Registration = new HealthCheckRegistration("REG1", hc, HealthStatus.Unhealthy, null)
+                };
+
+                var result = await hc.CheckHealthAsync(context, cancellationToken);
+                Assert.That(result.Status, Is.EqualTo(HealthStatus.Healthy));
+                Assert.That(result.Description, Is.EqualTo("Dapr process 'P1' attached, unverified version"));
             }
         }
 


### PR DESCRIPTION
# Description

If process status is `Attached` then health check is now correctly carried out against the attached sidecar.

## Issue reference

Fixes Issue #7 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation where possible
