### PR TITLE
Use "DaprSidekick" config section in preference to "Dapr"

### DIFF
--- a/samples/AspNetCore/ConsulSample/ConsulSample.Receiver/appsettings.json
+++ b/samples/AspNetCore/ConsulSample/ConsulSample.Receiver/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "Dapr": {
+  "DaprSidekick": {
     // Set the runtime location of config/components files to be the "dapr" folder under the deployed application
     "RuntimeDirectory": "dapr"
   },

--- a/samples/AspNetCore/ConsulSample/ConsulSample.Sender/appsettings.json
+++ b/samples/AspNetCore/ConsulSample/ConsulSample.Sender/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "Dapr": {
+  "DaprSidekick": {
     // Set the runtime location of config/components files to be the "dapr" folder under the deployed application
     "RuntimeDirectory": "dapr"
   },

--- a/src/Man.Dapr.Sidekick.AspNetCore/DaprSidekickServiceCollectionExtensions.cs
+++ b/src/Man.Dapr.Sidekick.AspNetCore/DaprSidekickServiceCollectionExtensions.cs
@@ -45,8 +45,18 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">A <see cref="IConfiguration"/> instance for configuring the component.</param>
         /// <param name="postConfigureAction">An optional action to configure the component after initial configuration is applied.</param>
         /// <returns>A <see cref="IDaprSidekickBuilder"/> for further configuration.</returns>
-        public static IDaprSidekickBuilder AddDaprSidekick(this IServiceCollection services, IConfiguration configuration, Action<DaprOptions> postConfigureAction = null) =>
-            AddDaprSidekick(services, DaprOptions.SectionName, configuration, postConfigureAction);
+        public static IDaprSidekickBuilder AddDaprSidekick(this IServiceCollection services, IConfiguration configuration, Action<DaprOptions> postConfigureAction = null)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            // Try to get primary section "DaprSidekick" first (v1.1+ default)
+            // Otherwise fall back to section "Dapr" (v1.0 default)
+            var sectionName = configuration.GetSection(DaprOptions.SectionName).Exists() ? DaprOptions.SectionName : "Dapr";
+            return AddDaprSidekick(services, sectionName, configuration, postConfigureAction);
+        }
 
         /// <summary>
         /// Adds the Dapr Sidecar process to the service container using the configuration section specified by <paramref name="name"/>.

--- a/src/Man.Dapr.Sidekick/Options/DaprOptions.cs
+++ b/src/Man.Dapr.Sidekick/Options/DaprOptions.cs
@@ -2,7 +2,7 @@
 {
     public class DaprOptions : Options.DaprProcessOptions
     {
-        public const string SectionName = "Dapr";
+        public const string SectionName = "DaprSidekick";
         public const string EnvironmentVariablePrefix = "DAPRSIDEKICK_";
 
         public DaprOptions()

--- a/tests/Man.Dapr.Sidekick.AspNetCore.Tests/DaprSidekickServiceCollectionExtensionsTests.cs
+++ b/tests/Man.Dapr.Sidekick.AspNetCore.Tests/DaprSidekickServiceCollectionExtensionsTests.cs
@@ -87,7 +87,44 @@ namespace Man.Dapr.Sidekick.AspNetCore.Sidecar
                 var options = provider.GetRequiredService<IOptions<DaprOptions>>();
                 Assert.That(options.Value.ProcessName, Is.EqualTo("PROCESS_NAME"));
                 Assert.That(provider.GetRequiredService<IDaprProcessFactory>(), Is.Not.Null);
-                configuration.Received(1).GetSection("Dapr");
+                configuration.Received(2).GetSection("DaprSidekick"); // One call to check section existence, another to get values
+            }
+
+            [Test]
+            public void Should_read_config_from_primary_section()
+            {
+                var configuration = new ConfigurationBuilder()
+                    .AddCommandLine(new[]
+                    {
+                        "Dapr:Enabled=false",
+                        "DaprSidekick:Enabled=true"
+                    })
+                    .Build();
+                var services = new ServiceCollection();
+                services.AddDaprSidekick(configuration);
+                var provider = services.BuildServiceProvider();
+                var options = provider.GetRequiredService<IOptions<DaprOptions>>();
+
+                // Should read value from "DaprSidekick" section
+                Assert.That(options.Value.Enabled, Is.True);
+            }
+
+            [Test]
+            public void Should_read_config_from_fallback_section()
+            {
+                var configuration = new ConfigurationBuilder()
+                    .AddCommandLine(new[]
+                    {
+                        "Dapr:Enabled=true"
+                    })
+                    .Build();
+                var services = new ServiceCollection();
+                services.AddDaprSidekick(configuration);
+                var provider = services.BuildServiceProvider();
+                var options = provider.GetRequiredService<IOptions<DaprOptions>>();
+
+                // Should read value from "Dapr" section
+                Assert.That(options.Value.Enabled, Is.True);
             }
 
             [Test]

--- a/tests/Man.Dapr.Sidekick.AspNetCore.Tests/DaprSidekickServiceCollectionExtensionsTests.cs
+++ b/tests/Man.Dapr.Sidekick.AspNetCore.Tests/DaprSidekickServiceCollectionExtensionsTests.cs
@@ -96,8 +96,8 @@ namespace Man.Dapr.Sidekick.AspNetCore.Sidecar
                 var configuration = new ConfigurationBuilder()
                     .AddCommandLine(new[]
                     {
-                        "Dapr:Enabled=false",
-                        "DaprSidekick:Enabled=true"
+                        "Dapr:ProcessName=VALUE_FROM_DAPR",
+                        "DaprSidekick:ProcessName=VALUE_FROM_DAPRSIDEKICK"
                     })
                     .Build();
                 var services = new ServiceCollection();
@@ -106,7 +106,7 @@ namespace Man.Dapr.Sidekick.AspNetCore.Sidecar
                 var options = provider.GetRequiredService<IOptions<DaprOptions>>();
 
                 // Should read value from "DaprSidekick" section
-                Assert.That(options.Value.Enabled, Is.True);
+                Assert.That(options.Value.ProcessName, Is.EqualTo("VALUE_FROM_DAPRSIDEKICK"));
             }
 
             [Test]
@@ -115,7 +115,7 @@ namespace Man.Dapr.Sidekick.AspNetCore.Sidecar
                 var configuration = new ConfigurationBuilder()
                     .AddCommandLine(new[]
                     {
-                        "Dapr:Enabled=true"
+                        "Dapr:ProcessName=VALUE_FROM_DAPR",
                     })
                     .Build();
                 var services = new ServiceCollection();
@@ -124,7 +124,7 @@ namespace Man.Dapr.Sidekick.AspNetCore.Sidecar
                 var options = provider.GetRequiredService<IOptions<DaprOptions>>();
 
                 // Should read value from "Dapr" section
-                Assert.That(options.Value.Enabled, Is.True);
+                Assert.That(options.Value.ProcessName, Is.EqualTo("VALUE_FROM_DAPR"));
             }
 
             [Test]


### PR DESCRIPTION
# Description

Configuration settings will now be read in preference from a "DaprSidekick" section, and fallback to the original "Dapr" section if it does not exist.

## Issue reference

Closes #8 

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation where possible
