### PR TITLE
Add UseDefaultPlacementHostAddress option

### DIFF
--- a/src/Man.Dapr.Sidekick/Options/DaprSidecarOptions.cs
+++ b/src/Man.Dapr.Sidekick/Options/DaprSidecarOptions.cs
@@ -161,6 +161,11 @@ namespace Man.Dapr.Sidekick
         public bool? UseDefaultDaprApiToken { get; set; }
 
         /// <summary>
+        /// Gets or sets a value that determines if the default Placement Host address is used when <see cref="PlacementHostAddress"/> is not specified. Defaults to <c>true</c>.
+        /// </summary>
+        public bool? UseDefaultPlacementHostAddress { get; set; }
+
+        /// <summary>
         /// Gets the address of the metdata endpoint, such as http://127.0.0.1:3500/v1.0/metadata.
         /// </summary>
         /// <returns>The metadata endpoint address.</returns>

--- a/src/Man.Dapr.Sidekick/Process/DaprSidecarProcess.cs
+++ b/src/Man.Dapr.Sidekick/Process/DaprSidecarProcess.cs
@@ -51,7 +51,7 @@ namespace Man.Dapr.Sidekick.Process
             }
 
             // Set local placement information
-            if (string.IsNullOrEmpty(options.PlacementHostAddress))
+            if (string.IsNullOrEmpty(options.PlacementHostAddress) && options.UseDefaultPlacementHostAddress != false)
             {
                 // If we have a local enabled placement running in this solution, then use that port
                 // else use the defaults from the Dapr CLI - 6050 (Windows) or 50005 (Non-Windows)

--- a/tests/Man.Dapr.Sidekick.Tests/Process/DaprSidecarProcessTests.cs
+++ b/tests/Man.Dapr.Sidekick.Tests/Process/DaprSidecarProcessTests.cs
@@ -42,6 +42,31 @@ namespace Man.Dapr.Sidekick.Process
                 Assert.That(newOptions.AppId, Is.EqualTo("TEST"));
                 Assert.That(newOptions.Namespace, Is.EqualTo("TESTNS"));
             }
+
+            [Test]
+            public void Should_use_default_placementhost_address()
+            {
+                var p = new MockDaprSidecarProcess();
+                var options = new DaprOptions();
+                var newOptions = p.GetProcessOptions(options);
+                Assert.That(newOptions.PlacementHostAddress, Is.EqualTo("127.0.0.1:6050"));
+            }
+
+            [Test]
+            public void Should_not_use_default_placementhost_address()
+            {
+                var p = new MockDaprSidecarProcess();
+                var options = new DaprOptions
+                {
+                    Sidecar = new DaprSidecarOptions
+                    {
+                        UseDefaultPlacementHostAddress = false
+                    }
+                };
+
+                var newOptions = p.GetProcessOptions(options);
+                Assert.That(newOptions.PlacementHostAddress, Is.Null);
+            }
         }
 
         public class AssignPorts


### PR DESCRIPTION
# Description

Adds a `UseDefaultPlacementHostAddress` Sidecar option so the default placement host address `127.0.0.1:6050` (on Windows) can be suppressed from the `daprd` command-line. Defaults to `true` so the behavior remains the same as the Dapr CLI unless overridden.

## Issue reference

Closes #6 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation where possible
