### PR TITLE
Delay Sidecar Startup until Host Application Started

### DIFF
--- a/src/Man.Dapr.Sidekick.AspNetCore/Sidecar/DaprSidecarHostedService.cs
+++ b/src/Man.Dapr.Sidekick.AspNetCore/Sidecar/DaprSidecarHostedService.cs
@@ -91,8 +91,9 @@ namespace Man.Dapr.Sidekick.AspNetCore.Sidecar
             }
         }
 
-        protected void WaitForApplicationStart(CancellationToken cancellationToken, ILogger logger = null)
+        protected void WaitForApplicationStart(CancellationToken cancellationToken)
         {
+            var logger = _serviceProvider?.GetService<ILogger<DaprSidecarHostedService>>();
 #if NETCOREAPP3_0_OR_GREATER
             var applicationLifetime = _serviceProvider?.GetService<IHostApplicationLifetime>();
 #else

--- a/src/Man.Dapr.Sidekick.AspNetCore/Sidecar/DaprSidecarHostedService.cs
+++ b/src/Man.Dapr.Sidekick.AspNetCore/Sidecar/DaprSidecarHostedService.cs
@@ -119,9 +119,6 @@ namespace Man.Dapr.Sidekick.AspNetCore.Sidecar
                 return;
             }
 
-            // Assign a default logger if none passed in
-            logger ??= _serviceProvider.GetService<ILogger<DaprSidecarHostedService>>();
-
             // Ensure the host has started
             while (!cancellationToken.IsCancellationRequested)
             {


### PR DESCRIPTION
# Description

Delay startup process in `DaprSidecarHostedService` until `IHostApplicationLifetime.ApplicationStarted` is signaled, indicating the port is open and the middleware pipeline is completed.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #36 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation where possible
