### PR TITLE
Added support for --resources-path parameter

### DIFF
--- a/src/Man.Dapr.Sidekick/Options/DaprSidecarOptions.cs
+++ b/src/Man.Dapr.Sidekick/Options/DaprSidecarOptions.cs
@@ -51,8 +51,16 @@ namespace Man.Dapr.Sidekick
         /// <summary>
         /// Gets or sets the path to the Dapr Components directory containing component configurations.
         /// If not specified this will default to a directory called "components" under the current dapr folder.
+        /// <br/>
+        /// <b>Deprecated</b> in favor of ResourcesDirectory.
         /// </summary>
         public string ComponentsDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the Dapr Resources directory containing component configurations.
+        /// If not specified this will default to a directory called "components" under the current dapr folder.
+        /// </summary>
+        public string ResourcesDirectory { get; set; }
 
         /// <summary>
         /// Gets or sets the path to the Dapr configuration file. If a filename is not specified the default value "config.yaml" will be used.

--- a/src/Man.Dapr.Sidekick/Process/DaprSidecarProcess.cs
+++ b/src/Man.Dapr.Sidekick/Process/DaprSidecarProcess.cs
@@ -13,6 +13,7 @@ namespace Man.Dapr.Sidekick.Process
         private const string AppProtocolArgument = "app-protocol";
         private const string AppSslArgument = "app-ssl";
         private const string ComponentsPathArgument = "components-path";
+        private const string ResourcesPathArgument = "resources-path";
         private const string ConfigFileArgument = "config";
         private const string ControlPlaneAddressArgument = "control-plane-address";
         private const string DaprGrpcPortArgument = "dapr-grpc-port";
@@ -80,6 +81,11 @@ namespace Man.Dapr.Sidekick.Process
 
         protected override void AssignLocations(DaprSidecarOptions options, string daprFolder)
         {
+            // Resources directory - defaults to <daprFolder>\components
+            var resourcesDirectory = string.IsNullOrEmpty(options.ResourcesDirectory) ?
+                Path.Combine(daprFolder, DaprConstants.DaprComponentsDirectory) :
+                Path.GetFullPath(options.ResourcesDirectory);
+
             // Components directory - defaults to <daprFolder>\components
             var componentsDirectory = string.IsNullOrEmpty(options.ComponentsDirectory) ?
                 Path.Combine(daprFolder, DaprConstants.DaprComponentsDirectory) :
@@ -92,6 +98,7 @@ namespace Man.Dapr.Sidekick.Process
                 Path.GetFullPath(options.ConfigFile);
 
             // Update the values
+            options.ResourcesDirectory = resourcesDirectory;
             options.ComponentsDirectory = componentsDirectory;
             options.ConfigFile = configFile;
         }
@@ -119,6 +126,7 @@ namespace Man.Dapr.Sidekick.Process
             .Add(ProfilePortArgument, source.ProfilePort, predicate: () => source.Profiling == true)
             .Add(SentryAddressArgument, source.SentryAddress, predicate: () => !source.SentryAddress.IsNullOrWhiteSpaceEx())
             .Add(ConfigFileArgument, source.ConfigFile, predicate: () => File.Exists(source.ConfigFile))
+            .Add(ResourcesPathArgument, source.ResourcesDirectory, predicate: () => Directory.Exists(source.ResourcesDirectory))
             .Add(ComponentsPathArgument, source.ComponentsDirectory, predicate: () => Directory.Exists(source.ComponentsDirectory))
             .Add(source.CustomArguments, requiresValue: false);
 
@@ -159,6 +167,10 @@ namespace Man.Dapr.Sidekick.Process
 
                 case AppProtocolArgument:
                     target.AppProtocol = value;
+                    break;
+
+                case ResourcesPathArgument:
+                    target.ResourcesDirectory = value;
                     break;
 
                 case ComponentsPathArgument:

--- a/tests/Man.Dapr.Sidekick.Tests/Options/DaprSidecarOptionsTests.cs
+++ b/tests/Man.Dapr.Sidekick.Tests/Options/DaprSidecarOptionsTests.cs
@@ -129,6 +129,7 @@ namespace Man.Dapr.Sidekick.Options
             Assert.That(target.AppPort, Is.EqualTo(source.AppPort));
             Assert.That(target.AppProtocol, Is.EqualTo(source.AppProtocol));
             Assert.That(target.AppSsl, Is.EqualTo(source.AppSsl));
+            Assert.That(target.ResourcesDirectory, Is.EqualTo(source.ResourcesDirectory));
             Assert.That(target.ComponentsDirectory, Is.EqualTo(source.ComponentsDirectory));
             Assert.That(target.ConfigFile, Is.EqualTo(source.ConfigFile));
             Assert.That(target.ControlPlaneAddress, Is.EqualTo(source.ControlPlaneAddress));
@@ -160,6 +161,7 @@ namespace Man.Dapr.Sidekick.Options
             AppPort = 200,
             AppProtocol = "AppProtocol",
             AppSsl = true,
+            ResourcesDirectory = "ResourcesDirectory",
             ComponentsDirectory = "ComponentsDirectory",
             ConfigFile = "ConfigFile",
             ControlPlaneAddress = "ControlPlaneAddress",

--- a/tests/Man.Dapr.Sidekick.Tests/Process/DaprSidecarProcessTests.cs
+++ b/tests/Man.Dapr.Sidekick.Tests/Process/DaprSidecarProcessTests.cs
@@ -116,6 +116,7 @@ namespace Man.Dapr.Sidekick.Process
 
                 p.AssignLocations(options, folder);
 
+                Assert.That(options.ResourcesDirectory, Is.EqualTo(Path.Combine(folder, "components")));
                 Assert.That(options.ComponentsDirectory, Is.EqualTo(Path.Combine(folder, "components")));
                 Assert.That(options.ConfigFile, Is.EqualTo(Path.Combine(folder, "config.yaml")));
             }
@@ -127,12 +128,14 @@ namespace Man.Dapr.Sidekick.Process
                 var folder = Path.GetTempPath();
                 var options = new DaprSidecarOptions
                 {
+                    ResourcesDirectory = folder + "comps",
                     ComponentsDirectory = folder + "comps",
                     ConfigFile = folder + "config.txt"
                 };
 
                 p.AssignLocations(options, folder);
 
+                Assert.That(options.ResourcesDirectory, Is.EqualTo(Path.Combine(folder, "comps")));
                 Assert.That(options.ComponentsDirectory, Is.EqualTo(Path.Combine(folder, "comps")));
                 Assert.That(options.ConfigFile, Is.EqualTo(Path.Combine(folder, "config.txt")));
             }
@@ -182,6 +185,7 @@ namespace Man.Dapr.Sidekick.Process
                     AppPort = 1234,
                     AppProtocol = "AppProtocol",
                     AppSsl = true,
+                    ResourcesDirectory = componentsPath, // Must exist
                     ComponentsDirectory = componentsPath, // Must exist
                     ConfigFile = configFile, // Must exist
                     ControlPlaneAddress = "ControlPlaneAddress",
@@ -226,6 +230,7 @@ namespace Man.Dapr.Sidekick.Process
                     "--profile-port 6789 " +
                     "--sentry-address SentryAddress " +
                     "--config " + configFile + " " +
+                    "--resources-path " + componentsPath + " " +
                     "--components-path " + componentsPath + " " +
                     "--arg1 val1"));
 
@@ -299,6 +304,7 @@ namespace Man.Dapr.Sidekick.Process
                 p.ParseCommandLineArgument(options, "app-port", "1234");
                 p.ParseCommandLineArgument(options, "app-protocol", "AppProtocol");
                 p.ParseCommandLineArgument(options, "app-ssl", null);
+                p.ParseCommandLineArgument(options, "resources-path", "ResourcesPath");
                 p.ParseCommandLineArgument(options, "components-path", "ComponentsPath");
                 p.ParseCommandLineArgument(options, "config", "ConfigFile");
                 p.ParseCommandLineArgument(options, "control-plane-address", "ControlPlaneAddress");
@@ -321,6 +327,7 @@ namespace Man.Dapr.Sidekick.Process
                 Assert.That(options.AppPort, Is.EqualTo(1234));
                 Assert.That(options.AppProtocol, Is.EqualTo("AppProtocol"));
                 Assert.That(options.AppSsl, Is.True);
+                Assert.That(options.ResourcesDirectory, Is.EqualTo("ResourcesPath"));
                 Assert.That(options.ComponentsDirectory, Is.EqualTo("ComponentsPath"));
                 Assert.That(options.ConfigFile, Is.EqualTo("ConfigFile"));
                 Assert.That(options.ControlPlaneAddress, Is.EqualTo("ControlPlaneAddress"));


### PR DESCRIPTION
# Description

Added support for --resources-path parameter to be used instead of the deprecated --components-path

## Issue reference
https://github.com/man-group/dapr-sidekick-dotnet/issues/52
The issue this PR will close: #52

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation where possible
