### PR TITLE
Feature/add working directory override

### DIFF
--- a/samples/AspNetCore/ControllerSample/ControllerSample/ControllerSample.csproj
+++ b/samples/AspNetCore/ControllerSample/ControllerSample/ControllerSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.2.0" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.11.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
   </ItemGroup>
 

--- a/samples/AspNetCore/ControllerSample/ControllerSample/Dapr/Components/pubsub.yaml
+++ b/samples/AspNetCore/ControllerSample/ControllerSample/Dapr/Components/pubsub.yaml
@@ -1,0 +1,12 @@
+﻿apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+    - name: redisHost
+      value: localhost:6379
+    - name: redisPassword
+      value: ""

--- a/samples/AspNetCore/ControllerSample/ControllerSample/Dapr/Components/secretstore.yaml
+++ b/samples/AspNetCore/ControllerSample/ControllerSample/Dapr/Components/secretstore.yaml
@@ -1,0 +1,12 @@
+﻿apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: localsecretstore
+  namespace: default
+spec:
+  type: secretstores.local.file
+  version: v1
+  metadata:
+    - name: secretsFile
+      value: "secrets.json"
+      

--- a/samples/AspNetCore/ControllerSample/ControllerSample/Startup.cs
+++ b/samples/AspNetCore/ControllerSample/ControllerSample/Startup.cs
@@ -3,6 +3,17 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Client;
+using Man.Dapr.Sidekick;
+using Man.Dapr.Sidekick.Threading;
+using Serilog;
+
 namespace ControllerSample
 {
     using Microsoft.AspNetCore.Builder;
@@ -20,9 +31,11 @@ namespace ControllerSample
         /// Initializes a new instance of the <see cref="Startup"/> class.
         /// </summary>
         /// <param name="configuration">Configuration.</param>
-        public Startup(IConfiguration configuration)
+        /// <param name="environment">environment.</param>
+        public Startup(IConfiguration configuration, IHostEnvironment environment)
         {
             Configuration = configuration;
+            Environment = environment;
         }
 
         /// <summary>
@@ -30,16 +43,55 @@ namespace ControllerSample
         /// </summary>
         public IConfiguration Configuration { get; }
 
+        public IHostEnvironment Environment { get; }
+
         /// <summary>
         /// Configures Services.
         /// </summary>
         /// <param name="services">Service Collection.</param>
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers().AddDapr();
+            // Manage local dapr sidecar
+            if (Environment.IsDevelopment())
+            {
+                // Set options in code
+                var sidecarOptions = new DaprSidecarOptions
+                {
+                    AppId = "controllersample",
+                    AppPort = 5000,
+                    ResourcesDirectory = Path.Combine(Environment.ContentRootPath, "Dapr/Components"),
 
-            // Add Dapr Sidekick
-            services.AddDaprSidekick(Configuration);
+                    // Set the working directory to our project to allow relative paths in component yaml files
+                    WorkingDirectory = Environment.ContentRootPath
+                };
+
+                // Build the default Sidekick controller
+                var sidekick = new DaprSidekickBuilder().Build();
+
+                // Start the Dapr Sidecar early in the pipeline, this will come up in the background
+                sidekick.Sidecar.Start(() => new DaprOptions { Sidecar = sidecarOptions }, DaprCancellationToken.None);
+
+                // Add Dapr Sidekick
+                services.AddDaprSidekick(Configuration, o =>
+                {
+                    o.Sidecar = sidecarOptions;
+                });
+            }
+
+            // Wait for the Dapr sidecar to report healthy before attempting to use any Dapr components.
+            var client = new DaprClientBuilder().Build();
+            using (var tokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
+            {
+                // use the await keyword in your service instead
+                client.WaitForSidecarAsync(tokenSource.Token).ConfigureAwait(false);
+            }
+
+            // Get secrets from store during startup
+            var secret = client.GetSecretAsync("localsecretstore", "secret").Result;
+
+            Log.Logger.Information("----- Secret: " + string.Join(",", secret.Select(d => d.Value)));
+
+            services.AddControllers().AddDapr();
         }
 
         /// <summary>

--- a/samples/AspNetCore/ControllerSample/ControllerSample/secrets.json
+++ b/samples/AspNetCore/ControllerSample/ControllerSample/secrets.json
@@ -1,0 +1,3 @@
+{
+  "secret": "YourPasskeyHere"
+}

--- a/src/Man.Dapr.Sidekick/Options/DaprProcessOptions.cs
+++ b/src/Man.Dapr.Sidekick/Options/DaprProcessOptions.cs
@@ -38,6 +38,13 @@ namespace Man.Dapr.Sidekick.Options
         public string InitialDirectory { get; set; }
 
         /// <summary>
+        /// Gets or sets a working directory to be used by the managed process.
+        /// This is required by some components that use relevant directory paths to load local files from the project folders.
+        /// Defaults to %USERPROFILE%/.dapr ($HOME/.dapr on Linux) if not specified.
+        /// </summary>
+        public string WorkingDirectory { get; set; }
+
+        /// <summary>
         /// Gets or sets the issuer certificate used for mTLS encryption.
         /// </summary>
         public SensitiveString IssuerCertificate { get; set; }

--- a/src/Man.Dapr.Sidekick/Process/DaprProcess.cs
+++ b/src/Man.Dapr.Sidekick/Process/DaprProcess.cs
@@ -343,7 +343,7 @@ namespace Man.Dapr.Sidekick.Process
             process.OutputDataReceived += (sender, args) => _daprLogger?.LogData(args.Data);
 
             // Start the managed dapr process
-            process.Start(proposedOptions.ProcessFile, arguments, Logger, cancellationToken: cancellationToken);
+            process.Start(proposedOptions.ProcessFile, proposedOptions.WorkingDirectory, arguments, Logger, cancellationToken: cancellationToken);
 
             // Handle unplanned exit
             process.UnplannedExit += (sender, args) =>

--- a/src/Man.Dapr.Sidekick/Process/ManagedProcess.cs
+++ b/src/Man.Dapr.Sidekick/Process/ManagedProcess.cs
@@ -31,12 +31,14 @@ namespace Man.Dapr.Sidekick.Process
         /// Starts a system process for a Dapr process binary.
         /// </summary>
         /// <param name="filename">The full path to the system process.</param>
+        /// <param name="workingDirectory">The working directory used by the process.</param>
         /// <param name="arguments">The optional command-line process arguments.</param>
         /// <param name="logger">An optional <see cref="IDaprLogger"/> instance for receiving stdout log messages from the process.</param>
         /// <param name="configureEnvironmentVariables">An optional action for configuring any environment variables for the process.</param>
         /// <param name="cancellationToken">A <see cref="DaprCancellationToken"/> for aborting the process startup operation.</param>
         public void Start(
             string filename,
+            string workingDirectory = null,
             string arguments = null,
             IDaprLogger logger = null,
             Action<StringDictionary> configureEnvironmentVariables = null,
@@ -55,6 +57,11 @@ namespace Man.Dapr.Sidekick.Process
                     throw new InvalidOperationException($"Unable to start process, file '{filename}' does not exist");
                 }
 
+                if (!string.IsNullOrEmpty(workingDirectory) && !Directory.Exists(workingDirectory))
+                {
+                    throw new InvalidOperationException($"Unable to start process, working directory '{workingDirectory}' does not exist");
+                }
+
                 try
                 {
                     // Initialize the process start info
@@ -67,7 +74,7 @@ namespace Man.Dapr.Sidekick.Process
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
                         RedirectStandardInput = true,
-                        WorkingDirectory = Path.GetDirectoryName(filename)
+                        WorkingDirectory = workingDirectory ?? Path.GetDirectoryName(filename)
                     };
 
                     // Add environment variables

--- a/tests/Man.Dapr.Sidekick.Tests/Process/ManagedProcessTests.cs
+++ b/tests/Man.Dapr.Sidekick.Tests/Process/ManagedProcessTests.cs
@@ -73,7 +73,7 @@ namespace Man.Dapr.Sidekick.Process
                     }
                 };
 
-                mp.Start(ProcessFilename, "ARG1=VAL1", logger);
+                mp.Start(ProcessFilename, null, "ARG1=VAL1", logger);
                 Assert.That(p, Is.Not.Null);
 
                 var psi = p.StartInfo;


### PR DESCRIPTION
# Description

- Added a WorkingDirectory option to allow us specify another directory to execute daprd.exe in. The requirement for this is to allow some components use relative file paths.
- Updated one of the example projects to start a sidecar earlier in the startup flow in order to be able to use secretstores components during startup to load secrets or configurations from them.

## Issue reference

https://github.com/man-group/dapr-sidekick-dotnet/issues/57
https://github.com/man-group/dapr-sidekick-dotnet/issues/58

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation where possible
