### PR TITLE
#64 : Only pass --scheduler-host-address in Dapr 1.14.0 and later

### DIFF
--- a/src/Man.Dapr.Sidekick/Process/DaprSidecarProcess.cs
+++ b/src/Man.Dapr.Sidekick/Process/DaprSidecarProcess.cs
@@ -135,7 +135,7 @@ namespace Man.Dapr.Sidekick.Process
             .Add(ModeArgument, source.Mode)
             .Add(PlacementHostAddressArgument, source.PlacementHostAddress)
             .Add(ProfilePortArgument, source.ProfilePort, predicate: () => source.Profiling == true)
-            .Add(SchedulerHostAddressArgument, source.SchedulerHostAddress)
+            .Add(SchedulerHostAddressArgument, source.SchedulerHostAddress, predicate: () => !source.IsRuntimeVersionEarlierThan("1.14.0"))
             .Add(SentryAddressArgument, source.SentryAddress, predicate: () => !source.SentryAddress.IsNullOrWhiteSpaceEx())
             .Add(ConfigFileArgument, source.ConfigFile, predicate: () => File.Exists(source.ConfigFile))
             .Add(ResourcesPathArgument, source.ResourcesDirectory, predicate: () => Directory.Exists(source.ResourcesDirectory))

--- a/tests/Man.Dapr.Sidekick.Tests/Process/DaprSidecarProcessTests.cs
+++ b/tests/Man.Dapr.Sidekick.Tests/Process/DaprSidecarProcessTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Man.Dapr.Sidekick.Logging;
 using Man.Dapr.Sidekick.Security;
 using NSubstitute;
@@ -263,7 +264,25 @@ namespace Man.Dapr.Sidekick.Process
 
                 File.Delete(configFile);
             }
-        }
+
+            [TestCase("1.13.2", false)]
+            [TestCase("1.14.0", true)]
+            public void Should_add_schedulerhostaddress_by_runtimeversion(string version, bool containsValue)
+            {
+                var p = new MockDaprSidecarProcess();
+                var builder = new CommandLineArgumentBuilder();
+                var options = new DaprSidecarOptions
+                {
+                    SchedulerHostAddress = "SchedulerHostAddress",
+                    RuntimeVersion = new Version(version)
+                };
+
+                p.AddCommandLineArguments(options, builder);
+
+                var expected = containsValue ? " --scheduler-host-address SchedulerHostAddress" : string.Empty;
+                Assert.That(builder.ToString(), Does.EndWith(expected));
+           }
+       }
 
         public class AddEnvironmentVariables
         {


### PR DESCRIPTION
# Description

Only pass `--scheduler-host-address` in Dapr 1.14.0 and later

## Issue reference

This completes #64 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation where possible
